### PR TITLE
Load only a subtree of the yaml file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ window.fetch(actualFilename).then(res => {
 });
 ```
 
+You can also returns only a part of the yaml file. For example with this yaml file:
+
+```yaml
+---
+config:
+  js:
+    key: test
+hello: world
+```
+
+If you only want the *config.js* part, you can use the param namespace:
+
+```js
+let config  = require("!json!yaml?namespace=config.js!my_file.yaml");
+```
+
+The namespace param is a serie of keys, dot separated.
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/index.js
+++ b/index.js
@@ -1,9 +1,16 @@
 var yaml = require('js-yaml');
+var loaderUtils = require('loader-utils');
 
 module.exports = function (source) {
   this.cacheable && this.cacheable();
   try {
     var res = yaml.safeLoad(source);
+    var options = loaderUtils.parseQuery(this.query);
+    if (options.namespace) {
+      res = options.namespace.split('.').reduce(function(acc, name) {
+        return acc[name];
+      }, res);
+    }
     return JSON.stringify(res, undefined, '\t');
   }
   catch (err) {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,15 @@
   "bugs": {
     "url": "https://github.com/okonet/yaml-loader/issues"
   },
+  "scripts": {
+    "test": "mocha"
+  },
   "homepage": "https://github.com/okonet/yaml-loader",
   "dependencies": {
-    "js-yaml": "^3.5.2"
+    "js-yaml": "^3.5.2",
+    "loader-utils": "^0.2.15"
+  },
+  "devDependencies": {
+    "mocha": "^3.0.2"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,22 @@
+var assert = require('assert');
+var yamlLoader = require('../');
+
+describe('yaml-loader', function() {
+  it('return stringify version of the yaml file', function() {
+    assert.equal(yamlLoader("---\nhello: world"), '{\n\t"hello": "world"\n}');
+  });
+
+  it('return a part of the yaml', function() {
+    var context = {
+      query: '?namespace=hello'
+    };
+    assert.equal(yamlLoader.call(context, "---\nhello:\n  world: plop"), '{\n\t"world": "plop"\n}');
+  });
+
+  it('return a sub-part of the yaml', function() {
+    var context = {
+      query: '?namespace=hello.world'
+    };
+    assert.equal(yamlLoader.call(context, "---\nhello:\n  world: plop"), '"plop"');
+  });
+});


### PR DESCRIPTION
I needed to only load a subtree of a yaml file and I didn't wanted to inflate the size of the module.

My proposal is to add a namespace param. You can use dots to return a deeper part of the yaml.
