### PR TITLE
Add the '-loader' suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module: {
     {
       test: /\.yaml$/,
       include: path.resolve('data'),
-      loader: 'yaml',
+      loader: 'yaml-loader',
     },
   ],
 }


### PR DESCRIPTION
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'yaml-loader' instead of 'yaml',
                 see https://webpack.js.org/migrate/3/#automatic-loader-module-name-extension-removed