### PR TITLE
Output JavaScript source by default, rather than JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ module.exports = {
     rules: [
       {
         test: /\.ya?ml$/,
-        type: 'json', // Required by Webpack v4
         use: 'yaml-loader'
       }
     ]
@@ -44,6 +43,10 @@ file.hello === 'world'
 ## Options
 
 In addition to all [`yaml` options](https://eemeli.org/yaml/#options), the loader supports the following additional options:
+
+### `asJSON`
+
+If enabled, the loader output is stringified JSON rather than stringified JavaScript. For Webpack v4, you'll need to set the rule to have `type: "json"`. Also useful for chaining with other loaders that expect JSON input.
 
 ### `asStream`
 

--- a/index.js
+++ b/index.js
@@ -2,11 +2,30 @@ const loaderUtils = require('loader-utils')
 const { stringify } = require('javascript-stringify')
 const YAML = require('yaml')
 
+const makeIdIterator = (prefix = 'v', i = 1) => ({ next: () => prefix + i++ })
+
 module.exports = function yamlLoader(src) {
   const { asJSON, asStream, namespace, ...options } = Object.assign(
     { prettyErrors: true },
     loaderUtils.getOptions(this)
   )
+
+  // keep track of repeated object references
+  const refs = new Map()
+  const idIter = makeIdIterator()
+  function addRef(ref, count) {
+    if (ref && typeof ref === 'object' && count > 1)
+      refs.set(ref, { id: idIter.next(), seen: false })
+  }
+  const stringifyWithRefs = value =>
+    stringify(value, (value, space, next) => {
+      const v = refs.get(value)
+      if (v) {
+        if (v.seen) return v.id
+        v.seen = true
+      }
+      return next(value)
+    })
 
   let res
   if (asStream) {
@@ -15,17 +34,20 @@ module.exports = function yamlLoader(src) {
     for (const doc of stream) {
       for (const warn of doc.warnings) this.emitWarning(warn)
       for (const err of doc.errors) throw err
-      res.push(doc.toJSON())
+      res.push(doc.toJSON(null, addRef))
     }
   } else {
     const doc = YAML.parseDocument(src, options)
     for (const warn of doc.warnings) this.emitWarning(warn)
     for (const err of doc.errors) throw err
     if (namespace) doc.contents = doc.getIn(namespace.split('.'))
-    res = doc.toJSON()
+    res = doc.toJSON(null, addRef)
   }
 
   if (asJSON) return JSON.stringify(res)
-  const str = stringify(res)
-  return `export default ${str};`
+  let str = ''
+  for (const [obj, { id }] of refs.entries())
+    str += `var ${id} = ${stringifyWithRefs(obj)};\n`
+  str += `export default ${stringifyWithRefs(res)};`
+  return str
 }

--- a/index.js
+++ b/index.js
@@ -2,27 +2,29 @@ var loaderUtils = require('loader-utils')
 var YAML = require('yaml')
 
 module.exports = function yamlLoader(src) {
-  const { asStream, namespace, ...options } = Object.assign(
+  const { asJSON, asStream, namespace, ...options } = Object.assign(
     { prettyErrors: true },
     loaderUtils.getOptions(this)
   )
 
+  let res
   if (asStream) {
     const stream = YAML.parseAllDocuments(src, options)
-    const res = []
+    res = []
     for (const doc of stream) {
       for (const warn of doc.warnings) this.emitWarning(warn)
       for (const err of doc.errors) throw err
       res.push(doc.toJSON())
     }
-    return JSON.stringify(res)
+  } else {
+    res = YAML.parse(src, options)
+    if (namespace) {
+      res = namespace.split('.').reduce(function(acc, name) {
+        return acc[name]
+      }, res)
+    }
   }
 
-  let res = YAML.parse(src, options)
-  if (namespace) {
-    res = namespace.split('.').reduce(function(acc, name) {
-      return acc[name]
-    }, res)
-  }
-  return JSON.stringify(res)
+  const json = JSON.stringify(res)
+  return asJSON ? json : `export default ${json};`
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -213,9 +213,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.0.tgz",
-      "integrity": "sha512-cTIudHnzuWLS56ik4DnRnqqNf8MkdUzV4iFFI1h7Jo9xvrpQROYaAnaSd2mHLQAzzZAPfATynX5ord6YlNYNMA==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -4502,11 +4502,11 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.3.tgz",
-      "integrity": "sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.1.tgz",
+      "integrity": "sha512-xbWX1ayUVoW8DPM8qxOBowac4XxSTi0mFLbiokRq880ViYglN+F3nJ4Dc2GdypXpykrknKS39d8I3lzFoHv1kA==",
       "requires": {
-        "@babel/runtime": "^7.8.7"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2134,6 +2134,11 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "javascript-stringify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.0.1.tgz",
+      "integrity": "sha512-yV+gqbd5vaOYjqlbk16EG89xB5udgjqQF3C5FAORDg4f/IS1Yc5ERCv5e/57yBcfJYw05V5JyIXabhwb75Xxow=="
+    },
     "jest": {
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-25.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "javascript-stringify": "^2.0.1",
     "loader-utils": "^1.4.0",
-    "yaml": "^1.8.3"
+    "yaml": "^1.9.1"
   },
   "devDependencies": {
     "jest": "^25.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "singleQuote": true
   },
   "dependencies": {
+    "javascript-stringify": "^2.0.1",
     "loader-utils": "^1.4.0",
     "yaml": "^1.8.3"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,20 @@
 const loader = require('../')
 
+describe('aliased objects', () => {
+  test('single document', () => {
+    const ctx = {}
+    const src = 'foo: &foo [&val foo]\nbar: *foo'
+    const res = loader.call(ctx, src)
+    expect(res).toBe("var v1 = ['foo'];\nexport default {foo:v1,bar:v1};")
+  })
+  test('document stream', () => {
+    const ctx = { query: { asStream: true } }
+    const src = 'foo: &foo [foo]\nbar: *foo\n---\nfoo: &foo [foo]\nbar: *foo'
+    const res = loader.call(ctx, src)
+    expect(res).toBe("var v1 = ['foo'];\nvar v2 = ['foo'];\nexport default [{foo:v1,bar:v1},{foo:v2,bar:v2}];")
+  })
+})
+
 describe('options.asJSON', () => {
   test('return stringify version of the yaml file', () => {
     const ctx = { query: { asJSON: true } }

--- a/test/test.js
+++ b/test/test.js
@@ -21,13 +21,13 @@ describe('options.namespace', () => {
   test('return a part of the yaml', () => {
     const ctx = { query: '?namespace=hello' }
     const res = loader.call(ctx, '---\nhello:\n  world: plop')
-    expect(res).toBe('export default {"world":"plop"};')
+    expect(res).toBe("export default {world:'plop'};")
   })
 
   test('return a sub-part of the yaml', () => {
     const ctx = { query: '?namespace=hello.world' }
     const res = loader.call(ctx, '---\nhello:\n  world: plop')
-    expect(res).toBe('export default "plop";')
+    expect(res).toBe("export default 'plop';")
   })
 })
 
@@ -36,9 +36,7 @@ describe('options.asStream', () => {
     const ctx = { query: { asStream: true } }
     const src = 'hello: world\n---\nsecond: document\n'
     const res = loader.call(ctx, src)
-    expect(res).toBe(
-      'export default [{"hello":"world"},{"second":"document"}];'
-    )
+    expect(res).toBe("export default [{hello:'world'},{second:'document'}];")
   })
 
   test('without asStream, fail to parse multiple documents', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -1,43 +1,51 @@
 const loader = require('../')
 
-test('return stringify version of the yaml file', () => {
-  const res = loader('---\nhello: world')
-  expect(res).toBe('{"hello":"world"}')
+describe('options.asJSON', () => {
+  test('return stringify version of the yaml file', () => {
+    const ctx = { query: { asJSON: true } }
+    const src = '---\nhello: world'
+    const res = loader.call(ctx, src)
+    expect(res).toBe('{"hello":"world"}')
+  })
+
+  test('throw error if there is a parse error', () => {
+    const ctx = { query: { asJSON: true } }
+    const src = '---\nhello: world\nhello: 2'
+    expect(() => loader.call(ctx, src)).toThrow(
+      /^Map keys must be unique; "hello" is repeated/
+    )
+  })
 })
 
-test('throw error if there is a parse error', () => {
-  let msg = null
-  try {
-    loader('---\nhello: world\nhello: 2')
-  } catch (error) {
-    msg = error.message
-  }
-  expect(msg).toMatch(/^Map keys must be unique; "hello" is repeated/)
+describe('options.namespace', () => {
+  test('return a part of the yaml', () => {
+    const ctx = { query: '?namespace=hello' }
+    const res = loader.call(ctx, '---\nhello:\n  world: plop')
+    expect(res).toBe('export default {"world":"plop"};')
+  })
+
+  test('return a sub-part of the yaml', () => {
+    const ctx = { query: '?namespace=hello.world' }
+    const res = loader.call(ctx, '---\nhello:\n  world: plop')
+    expect(res).toBe('export default "plop";')
+  })
 })
 
-test('return a part of the yaml', () => {
-  const ctx = { query: '?namespace=hello' }
-  const res = loader.call(ctx, '---\nhello:\n  world: plop')
-  expect(res).toBe('{"world":"plop"}')
-})
+describe('options.asStream', () => {
+  test('with asStream, parse multiple documents', () => {
+    const ctx = { query: { asStream: true } }
+    const src = 'hello: world\n---\nsecond: document\n'
+    const res = loader.call(ctx, src)
+    expect(res).toBe(
+      'export default [{"hello":"world"},{"second":"document"}];'
+    )
+  })
 
-test('return a sub-part of the yaml', () => {
-  const ctx = { query: '?namespace=hello.world' }
-  const res = loader.call(ctx, '---\nhello:\n  world: plop')
-  expect(res).toBe('"plop"')
-})
-
-test('with asStream, parse multiple documents', () => {
-  const ctx = { query: { asStream: true } }
-  const src = 'hello: world\n---\nsecond: document\n'
-  const res = loader.call(ctx, src)
-  expect(res).toBe('[{"hello":"world"},{"second":"document"}]')
-})
-
-test('without asStream, fail to parse multiple documents', () => {
-  const ctx = { query: { asStream: false } }
-  const src = 'hello: world\n---\nsecond: document\n'
-  expect(() => loader.call(ctx, src)).toThrow(
-    /^Source contains multiple documents/
-  )
+  test('without asStream, fail to parse multiple documents', () => {
+    const ctx = { query: { asStream: false } }
+    const src = 'hello: world\n---\nsecond: document\n'
+    expect(() => loader.call(ctx, src)).toThrow(
+      /^Source contains multiple documents/
+    )
+  })
 })


### PR DESCRIPTION
At the moment, a Webpack rule using this loader needs to specify `type: 'json'` to note that its output is JSON, rather than the default expectation of JavaScript source.

This PR switches the loader's output to be stringified JavaScript, and adds a new option `asJSON` to restore the previous JSON output.

Feature-wise, this adds proper support for repeated references, as well as BigInt, Buffer, Date, Map, Set and practically any other ECMAScript value types that a YAML schema may produce.

Circular references result in `undefined` for the inner reference; that's currently blocked by blakeembrey/javascript-stringify#34.