### PR TITLE
Switch to js-yaml instead of yaml package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # yaml-loader for Webpack
 
-YAML loader for [Webpack](https://webpack.js.org/). Allows importing YAML files as JS objects. Uses [`yaml`](https://www.npmjs.com/package/yaml) internally.
+YAML loader for [Webpack](https://webpack.js.org/). Allows importing YAML files as JS objects. Uses [`js-yaml`](https://www.npmjs.com/package/js-yaml) internally.
 
 ## Installation
 
@@ -42,11 +42,12 @@ file.hello === 'world'
 
 ## Options
 
-In addition to all [`yaml` options](https://eemeli.org/yaml/#options), the loader supports the following additional options:
+In addition to all [`js-yaml` options](https://www.npmjs.com/package/js-yaml#API), the loader supports the following additional options:
 
 ### `asJSON`
 
 If enabled, the loader output is stringified JSON rather than stringified JavaScript. For Webpack v4, you'll need to set the rule to have `type: "json"`. Also useful for chaining with other loaders that expect JSON input.
+
 
 ### `asStream`
 
@@ -77,18 +78,6 @@ module.exports = {
 ```
 
 Then, importing `./foo.yaml` will expect it to contain only one document, but `./bar.yaml?stream` may contain multiple documents.
-
-### `namespace`
-
-Allows for exposing a sub-tree of the source document:
-
-```js
-import jsCfg from './file.yaml?namespace=config.js'
-
-jsCfg.key === 'test'
-```
-
-The `namespace` should be a series of keys, dot separated. Note that any `options` object in your `webpack.config.js` rule will be superseded by a `?query`.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { getOptions } = require('loader-utils')
 const { stringify } = require('javascript-stringify')
-const YAML = require('yaml')
+const YAML = require('js-yaml')
 
 const makeIdIterator = (prefix = 'v', i = 1) => ({ next: () => prefix + i++ })
 
@@ -27,21 +27,16 @@ module.exports = function yamlLoader(src) {
       return next(value)
     })
 
+  options['onWarning'] = options['onWarning'] || this.emitWarning
   let res
   if (asStream) {
-    const stream = YAML.parseAllDocuments(src, options)
+    const stream = YAML.loadAll(src, options)
     res = []
     for (const doc of stream) {
-      for (const warn of doc.warnings) this.emitWarning(warn)
-      for (const err of doc.errors) throw err
-      res.push(doc.toJSON(null, addRef))
+      res.push(doc)
     }
   } else {
-    const doc = YAML.parseDocument(src, options)
-    for (const warn of doc.warnings) this.emitWarning(warn)
-    for (const err of doc.errors) throw err
-    if (namespace) doc.contents = doc.getIn(namespace.split('.'))
-    res = doc.toJSON(null, addRef)
+    res = YAML.load(src, options)
   }
 
   if (asJSON) return JSON.stringify(res)

--- a/package-lock.json
+++ b/package-lock.json
@@ -414,6 +414,27 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "@istanbuljs/schema": {
@@ -835,13 +856,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -2815,13 +2832,11 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsbn": {
@@ -4670,11 +4685,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
-    },
-    "yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "dependencies": {
     "javascript-stringify": "^2.0.1",
-    "loader-utils": "^2.0.0",
-    "yaml": "^1.10.0"
+    "js-yaml": "^4.0.0",
+    "loader-utils": "^2.0.0"
   },
   "devDependencies": {
     "jest": "^26.4.2",


### PR DESCRIPTION
js-yaml includes support for <<: syntax and is
also what our tests use to parse yaml, so using
js-yaml in yaml-loader for webpack should lead
to more predictable behavior.